### PR TITLE
updated plugin name fetch usage to fix NPE when offline

### DIFF
--- a/src/com/softwareco/intellij/plugin/KeystrokeCount.java
+++ b/src/com/softwareco/intellij/plugin/KeystrokeCount.java
@@ -41,7 +41,7 @@ public class KeystrokeCount {
     public boolean triggered = false;
 
     public KeystrokeCount() {
-        String appVersion = SoftwareCo.getVersion();
+        String appVersion = SoftwareCoUtils.getVersion();
         if (appVersion != null) {
             this.version = appVersion;
         } else {

--- a/src/com/softwareco/intellij/plugin/SoftwareCo.java
+++ b/src/com/softwareco/intellij/plugin/SoftwareCo.java
@@ -7,8 +7,6 @@ package com.softwareco.intellij.plugin;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.intellij.ide.plugins.IdeaPluginDescriptor;
-import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.components.ApplicationComponent;
 import com.intellij.openapi.editor.EditorFactory;
@@ -44,43 +42,6 @@ public class SoftwareCo implements ApplicationComponent {
     public SoftwareCo() {
     }
 
-    private static IdeaPluginDescriptor getIdeaPluginDescriptor() {
-        IdeaPluginDescriptor[] desriptors = PluginManager.getPlugins();
-        if (desriptors != null && desriptors.length > 0) {
-            for (int i = 0; i < desriptors.length; i++) {
-                IdeaPluginDescriptor descriptor = desriptors[i];
-                if (descriptor.getPluginId().getIdString().equals("com.softwareco.intellij.plugin")) {
-                    return descriptor;
-                }
-            }
-        }
-        return null;
-    }
-
-    public static String getVersion() {
-        if (SoftwareCoUtils.VERSION == null) {
-            IdeaPluginDescriptor pluginDescriptor = getIdeaPluginDescriptor();
-            if (pluginDescriptor != null) {
-                SoftwareCoUtils.VERSION = pluginDescriptor.getVersion();
-            } else {
-                return "2.0.1";
-            }
-        }
-        return SoftwareCoUtils.VERSION;
-    }
-
-    public static String getPluginName() {
-        if (SoftwareCoUtils.pluginName == null) {
-            IdeaPluginDescriptor pluginDescriptor = getIdeaPluginDescriptor();
-            if (pluginDescriptor != null) {
-                SoftwareCoUtils.pluginName = pluginDescriptor.getName();
-            } else {
-                return "Code Time";
-            }
-        }
-        return SoftwareCoUtils.pluginName;
-    }
-
     public void initComponent() {
         boolean serverIsOnline = SoftwareCoSessionManager.isServerOnline();
         String jwt = FileManager.getItem("jwt");
@@ -94,7 +55,6 @@ public class SoftwareCo implements ApplicationComponent {
                 final Runnable service = () -> initComponent();
                 AsyncManager.getInstance().executeOnceInSeconds(service, 60);
             } else {
-                getPluginName();
                 // create the anon user
                 jwt = SoftwareCoUtils.createAnonymousUser();
                 if (jwt == null) {
@@ -116,9 +76,9 @@ public class SoftwareCo implements ApplicationComponent {
     }
 
     protected void initializePlugin(boolean initializedUser) {
-        String plugName = getPluginName();
+        String plugName = SoftwareCoUtils.getPluginName();
 
-        log.info(plugName + ": Loaded v" + getVersion());
+        log.info(plugName + ": Loaded v" + SoftwareCoUtils.getVersion());
 
         initializeUserInfoWhenProjectsReady(initializedUser);
 

--- a/src/com/softwareco/intellij/plugin/SoftwareCoUtils.java
+++ b/src/com/softwareco/intellij/plugin/SoftwareCoUtils.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.gson.*;
 import com.google.gson.stream.JsonReader;
 import com.intellij.ide.BrowserUtil;
+import com.intellij.ide.plugins.IdeaPluginDescriptor;
+import com.intellij.ide.plugins.PluginManager;
 import com.intellij.openapi.application.ApplicationManager;
 import com.intellij.openapi.editor.Editor;
 import com.intellij.openapi.editor.EditorFactory;
@@ -113,6 +115,43 @@ public class SoftwareCoUtils {
 
         pingClient = HttpClientBuilder.create().setDefaultRequestConfig(config).build();
         httpClient = HttpClientBuilder.create().build();
+    }
+
+    public static String getVersion() {
+        if (VERSION == null) {
+            IdeaPluginDescriptor pluginDescriptor = getIdeaPluginDescriptor();
+            if (pluginDescriptor != null) {
+                SoftwareCoUtils.VERSION = pluginDescriptor.getVersion();
+            } else {
+                return "2.0.1";
+            }
+        }
+        return SoftwareCoUtils.VERSION;
+    }
+
+    public static String getPluginName() {
+        if (pluginName == null) {
+            IdeaPluginDescriptor pluginDescriptor = getIdeaPluginDescriptor();
+            if (pluginDescriptor != null) {
+                SoftwareCoUtils.pluginName = pluginDescriptor.getName();
+            } else {
+                return "Code Time";
+            }
+        }
+        return SoftwareCoUtils.pluginName;
+    }
+
+    private static IdeaPluginDescriptor getIdeaPluginDescriptor() {
+        IdeaPluginDescriptor[] desriptors = PluginManager.getPlugins();
+        if (desriptors != null && desriptors.length > 0) {
+            for (int i = 0; i < desriptors.length; i++) {
+                IdeaPluginDescriptor descriptor = desriptors[i];
+                if (descriptor.getPluginId().getIdString().equals("com.softwareco.intellij.plugin")) {
+                    return descriptor;
+                }
+            }
+        }
+        return null;
     }
 
     public static String getWorkspaceName() {
@@ -346,7 +385,7 @@ public class SoftwareCoUtils {
                                 }
                             }
                         } catch (IOException e) {
-                            String errorMessage = pluginName + ": Unable to get the response from the http request, error: " + e.getMessage();
+                            String errorMessage = getPluginName() + ": Unable to get the response from the http request, error: " + e.getMessage();
                             softwareResponse.setErrorMessage(errorMessage);
                             LOG.log(Level.WARNING, errorMessage);
                         }
@@ -362,7 +401,7 @@ public class SoftwareCoUtils {
                     }
                 }
             } catch (InterruptedException | ExecutionException e) {
-                String errorMessage = pluginName + ": Unable to get the response from the http request, error: " + e.getMessage();
+                String errorMessage = getPluginName() + ": Unable to get the response from the http request, error: " + e.getMessage();
                 softwareResponse.setErrorMessage(errorMessage);
                 LOG.log(Level.WARNING, errorMessage);
             }
@@ -455,7 +494,7 @@ public class SoftwareCoUtils {
                         String kpmmsgId = SoftwareCoStatusBarKpmTextWidget.KPM_TEXT_ID + "_kpmmsg";
                         String kpmiconId = SoftwareCoStatusBarKpmIconWidget.KPM_ICON_ID + "_kpmicon";
 
-                        String kpmMsgVal = kpmMsg != null ? kpmMsg : pluginName;
+                        String kpmMsgVal = kpmMsg != null ? kpmMsg : getPluginName();
 
                         String kpmIconVal = kpmIcon;
                         if (!showStatusText) {
@@ -834,7 +873,7 @@ public class SoftwareCoUtils {
                         "We will try to reconnect again " + reconnectMsg +
                         "Your status bar will not update at this time.";
                 // ask to download the PM
-                Messages.showInfoMessage(infoMsg, pluginName);
+                Messages.showInfoMessage(infoMsg, getPluginName());
             }
         });
     }

--- a/src/com/softwareco/intellij/plugin/SoftwareCoUtils.java
+++ b/src/com/softwareco/intellij/plugin/SoftwareCoUtils.java
@@ -142,10 +142,9 @@ public class SoftwareCoUtils {
     }
 
     private static IdeaPluginDescriptor getIdeaPluginDescriptor() {
-        IdeaPluginDescriptor[] desriptors = PluginManager.getPlugins();
-        if (desriptors != null && desriptors.length > 0) {
-            for (int i = 0; i < desriptors.length; i++) {
-                IdeaPluginDescriptor descriptor = desriptors[i];
+        IdeaPluginDescriptor[] descriptors = PluginManager.getPlugins();
+        if (descriptors != null && descriptors.length > 0) {
+            for (IdeaPluginDescriptor descriptor : descriptors) {
                 if (descriptor.getPluginId().getIdString().equals("com.softwareco.intellij.plugin")) {
                     return descriptor;
                 }

--- a/src/com/softwareco/intellij/plugin/SoftwareHttpManager.java
+++ b/src/com/softwareco/intellij/plugin/SoftwareHttpManager.java
@@ -66,8 +66,8 @@ public class SoftwareHttpManager implements Callable<HttpResponse> {
 
             SoftwareCoUtils.TimesData timesData = SoftwareCoUtils.getTimesData();
             req.addHeader("X-SWDC-Plugin-Id", String.valueOf(SoftwareCoUtils.pluginId));
-            req.addHeader("X-SWDC-Plugin-Name", SoftwareCo.getPluginName());
-            req.addHeader("X-SWDC-Plugin-Version", SoftwareCo.getVersion());
+            req.addHeader("X-SWDC-Plugin-Name", SoftwareCoUtils.getPluginName());
+            req.addHeader("X-SWDC-Plugin-Version", SoftwareCoUtils.getVersion());
             req.addHeader("X-SWDC-Plugin-OS", SoftwareCoUtils.getOs());
             req.addHeader("X-SWDC-Plugin-TZ", timesData.timezone);
             req.addHeader("X-SWDC-Plugin-Offset", String.valueOf(timesData.offset));

--- a/src/com/softwareco/intellij/plugin/managers/EventTrackerManager.java
+++ b/src/com/softwareco/intellij/plugin/managers/EventTrackerManager.java
@@ -228,8 +228,8 @@ public class EventTrackerManager {
 
     private PluginEntity getPluginEntity() {
         PluginEntity pluginEntity = new PluginEntity();
-        pluginEntity.plugin_name = SoftwareCo.getPluginName();
-        pluginEntity.plugin_version = SoftwareCo.getVersion();
+        pluginEntity.plugin_name = SoftwareCoUtils.getPluginName();
+        pluginEntity.plugin_version = SoftwareCoUtils.getVersion();
         pluginEntity.plugin_id = SoftwareCoUtils.pluginId;
         return pluginEntity;
     }


### PR DESCRIPTION
this fixes a NPE that is thrown if a user is offline and trying to show the plugin name

java.lang.NullPointerException
	at com.intellij.ui.messages.SheetMessage.<init>(SheetMessage.java:77)
	at com.intellij.ui.messages.JBMacMessages.showOkMessageDialog(JBMacMessages.java:91)
	at com.intellij.openapi.ui.Messages.showInfoMessage(Messages.java:1328)
	at com.softwareco.intellij.plugin.SoftwareCoUtils$2.run(SoftwareCoUtils.java:837)